### PR TITLE
Curl now follows github redirects in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ fi
 
 # Download corresponding archive
 echo "INFO: Downloading the \"$ARCHIVE_NAME\"..."
-curl -s https://api.github.com/repos/k0kubun/xremap/releases/latest \
+curl -sL https://api.github.com/repos/k0kubun/xremap/releases/latest \
 | grep $ARCHIVE_NAME \
 | cut -d : -f 2,3 \
 | tr -d \" \


### PR DESCRIPTION
Simple Bugfix.
Currently the curl command in Install.sh gives the following response without the -L flag:
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/75132102/releases/latest",
  "documentation_url": "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
}

The -L flag follows the redirect and fixes it.